### PR TITLE
Cell connect

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -93,7 +93,8 @@ downloading/cloning this repository and using *pip*::
    cd <pype9-repo-dir>
    pip install -r requirements.txt .
 
-If you cannot use *pip* you will need to manually install the *libninemlnrn*
+If you cannot use *pip*, or have updated your Neuron installation and it uses
+a different compiler (e.g. mpicc), you will need to manually install the *libninemlnrn*
 shared library, which contains wrappers for GSL random distribution functions, with:: 
 
    cd <pype9-repo-dir>/pype9/neuron/cells/code_gen/libninemlnrn

--- a/pype9/exceptions.py
+++ b/pype9/exceptions.py
@@ -2,7 +2,7 @@ class Pype9Exception(Exception):
     pass
 
 
-class Pype9NotSupportedBySimulatorException(Pype9Exception):
+class Pype9Unsupported9MLException(Pype9Exception):
     pass
 
 

--- a/pype9/simulator/base/cells/base.py
+++ b/pype9/simulator/base/cells/base.py
@@ -18,6 +18,7 @@ import neo
 import nineml
 from nineml.abstraction import Dynamics, Regime
 from nineml.user import Property, Initial
+from nineml.exceptions import NineMLNameError
 from pype9.annotations import PYPE9_NS
 from pype9.exceptions import (
     Pype9RuntimeError, Pype9AttributeError, Pype9DimensionError,
@@ -410,9 +411,38 @@ class Cell(object):
             name='{}_regimes'.format(self.name))
 
     def play(self, port_name, signal, properties=[]):
+        """
+        Injects current into the segment
+
+        Parameters
+        ----------
+        port_name : str
+            The name of the receive port to play the signal into
+        signal : neo.AnalogSignal (current) | neo.SpikeTrain
+            Signal to play into the port
+        properties : list(nineml.Property)
+            The connection properties of the event port
+        """
         raise NotImplementedError("Should be implemented by derived class")
 
-    def connect(self, port_name, other, other_port_name):
+    def connect(self, sender, send_port_name, receive_port_name, delay,
+                properties=[]):
+        """
+        Connects a port of the cell to a matching port on the 'other' cell
+
+        Parameters
+        ----------
+        sender : pype9.simulator.base.cells.Cell
+            The sending cell to connect the from
+        send_port_name : str
+            Name of the port in the sending cell to connect to
+        receive_port_name : str
+            Name of the receive port in the current cell to connect from
+        delay : nineml.Quantity (time)
+            The delay of the connection
+        properties : list(nineml.Property)
+            The connection properties of the event port
+        """
         raise NotImplementedError("Should be implemented by derived class")
 
     # This has to go last to avoid clobbering the property decorators
@@ -421,10 +451,12 @@ class Cell(object):
 
     def _check_connection_properties(self, port_name, properties):
         props_dict = dict((p.name, p) for p in properties)
-        params_dict = dict(
-            (p.name, p) for p in
-            self._nineml.component_class.connection_parameter_set(
-                port_name).parameters)
+        try:
+            param_set = self._nineml.component_class.connection_parameter_set(
+                port_name)
+        except NineMLNameError:
+            return  # No parameter set, so no need to check
+        params_dict = dict((p.name, p) for p in param_set.parameters)
         if set(props_dict.iterkeys()) != set(params_dict.iterkeys()):
             raise Pype9RuntimeError(
                 "Mismatch between provided property and parameter names:"

--- a/pype9/simulator/nest/cells/base.py
+++ b/pype9/simulator/nest/cells/base.py
@@ -266,15 +266,10 @@ class Cell(base.Cell):
                     properties[0].quantity)
             nest.Connect(sender._cell, self._cell, syn_spec=syn_spec)
         elif receive_port.communicates == 'analog':
-            if self.component_class.num_analog_send_ports > 1:
-                raise Pype9Unsupported9MLException(
-                    "Cannot currently differentiate between multiple analog "
-                    "send ports in NEST implementation ('{}')".format(
-                        "', '".join(
-                            self.component_class.event_send_port_names)))
-            nest.Connect(sender._cell, self._cell, syn_spec={
-                "receptor_type": self._receive_ports[receive_port_name],
-                'delay': delay})
+            raise Pype9UsageError(
+                "Cannot individually 'connect' analog ports. Simulate the "
+                "sending cell in a separate simulation then play the analog "
+                "signal in the port")
         else:
             assert False
 

--- a/pype9/simulator/nest/cells/base.py
+++ b/pype9/simulator/nest/cells/base.py
@@ -219,7 +219,7 @@ class Cell(base.Cell):
                 "Unrecognised port type '{}' to play signal into".format(port))
 
     def connect(self, sender, send_port_name, receive_port_name, delay=None,
-                properties=[]):
+                properties=None):
         """
         Connects a port of the cell to a matching port on the 'other' cell
 
@@ -238,6 +238,8 @@ class Cell(base.Cell):
         """
         if delay is None:
             delay = self._device_delay
+        if properties is None:
+            properties = []
         delay = float(delay.in_units(un.ms))
         send_port = sender.component_class.send_port(send_port_name)
         receive_port = self.component_class.receive_port(receive_port_name)
@@ -271,7 +273,9 @@ class Cell(base.Cell):
                 "sending cell in a separate simulation then play the analog "
                 "signal in the port")
         else:
-            assert False
+            raise Pype9UsageError(
+                "Unrecognised port communication '{}'".format(
+                    receive_port.communicates))
 
     def voltage_clamp(self, voltages, series_resistance=1e-3):
         raise NotImplementedError("voltage clamps are not supported for "

--- a/pype9/simulator/nest/cells/base.py
+++ b/pype9/simulator/nest/cells/base.py
@@ -23,7 +23,7 @@ from pype9.simulator.base.cells import base
 from pype9.annotations import PYPE9_NS, MEMBRANE_VOLTAGE, BUILD_TRANS
 from pype9.simulator.nest.units import UnitHandler
 from pype9.exceptions import (
-    Pype9UsageError, Pype9NotSupportedBySimulatorException)
+    Pype9UsageError, Pype9Unsupported9MLException)
 from pype9.utils import add_lib_path
 
 
@@ -217,6 +217,66 @@ class Cell(base.Cell):
         else:
             raise Pype9UsageError(
                 "Unrecognised port type '{}' to play signal into".format(port))
+
+    def connect(self, sender, send_port_name, receive_port_name, delay=None,
+                properties=[]):
+        """
+        Connects a port of the cell to a matching port on the 'other' cell
+
+        Parameters
+        ----------
+        sender : pype9.simulator.nest.cells.Cell
+            The sending cell to connect the from
+        send_port_name : str
+            Name of the port in the sending cell to connect to
+        receive_port_name : str
+            Name of the receive port in the current cell to connect from
+        delay : nineml.Quantity (time)
+            The delay of the connection
+        properties : list(nineml.Property)
+            The connection properties of the event port
+        """
+        if delay is None:
+            delay = self._device_delay
+        delay = float(delay.in_units(un.ms))
+        send_port = sender.component_class.send_port(send_port_name)
+        receive_port = self.component_class.receive_port(receive_port_name)
+        if send_port.communicates != receive_port.communicates:
+            raise Pype9UsageError(
+                "Cannot connect {} send port, '{}', to {} receive port, '{}'"
+                .format(send_port.communicates, send_port_name,
+                        receive_port.communicates, receive_port_name))
+        if receive_port.communicates == 'event':
+            if self.component_class.num_event_send_ports > 1:
+                raise Pype9Unsupported9MLException(
+                    "Cannot currently differentiate between multiple event "
+                    "send ports in NEST implementation ('{}')".format(
+                        "', '".join(
+                            self.component_class.event_send_port_names)))
+            syn_spec = {'receptor_type':
+                        self._receive_ports[receive_port_name],
+                        'delay': delay}
+            if len(properties) > 1:
+                raise Pype9Unsupported9MLException(
+                    "Cannot handle more than one connection property per port")
+            elif properties:
+                self._check_connection_properties(receive_port_name,
+                                                  properties)
+                syn_spec['weight'] = self.UnitHandler.scale_value(
+                    properties[0].quantity)
+            nest.Connect(sender._cell, self._cell, syn_spec=syn_spec)
+        elif receive_port.communicates == 'analog':
+            if self.component_class.num_analog_send_ports > 1:
+                raise Pype9Unsupported9MLException(
+                    "Cannot currently differentiate between multiple analog "
+                    "send ports in NEST implementation ('{}')".format(
+                        "', '".join(
+                            self.component_class.event_send_port_names)))
+            nest.Connect(sender._cell, self._cell, syn_spec={
+                "receptor_type": self._receive_ports[receive_port_name],
+                'delay': delay})
+        else:
+            assert False
 
     def voltage_clamp(self, voltages, series_resistance=1e-3):
         raise NotImplementedError("voltage clamps are not supported for "

--- a/pype9/simulator/neuron/cells/base.py
+++ b/pype9/simulator/neuron/cells/base.py
@@ -24,7 +24,7 @@ import neo
 from .code_gen import CodeGenerator, REGIME_VARNAME
 from neuron import h, load_mechanisms
 from nineml import units as un
-from nineml.abstraction import EventPort, AnalogPort
+from nineml.abstraction import EventPort
 from nineml.exceptions import NineMLNameError
 from math import pi
 from pype9.simulator.base.cells import base
@@ -376,7 +376,7 @@ class Cell(base.Cell):
             self._input_auxs.extend((iclamp_amps, iclamp_times))
 
     def connect(self, sender, send_port_name, receive_port_name,
-                delay=0.0 * un.ms, properties=[]):
+                delay=0.0 * un.ms, properties=None):
         """
         Connects a port of the cell to a matching port on the 'other' cell
 
@@ -396,6 +396,8 @@ class Cell(base.Cell):
         send_port = sender.component_class.send_port(send_port_name)
         receive_port = self.component_class.receive_port(receive_port_name)
         delay = float(delay.in_units(un.ms))
+        if properties is None:
+            properties = []
         if send_port.communicates != receive_port.communicates:
             raise Pype9UsageError(
                 "Cannot connect {} send port, '{}', to {} receive port, '{}'"
@@ -425,7 +427,9 @@ class Cell(base.Cell):
                 "sending cell in a separate simulation then play the analog "
                 "signal in the port")
         else:
-            assert False
+            raise Pype9UsageError(
+                "Unrecognised port communication '{}'".format(
+                    receive_port.communicates))
 
     def voltage_clamp(self, voltages, series_resistance=1e-3):
         """

--- a/pype9/simulator/neuron/cells/base.py
+++ b/pype9/simulator/neuron/cells/base.py
@@ -420,14 +420,10 @@ class Cell(base.Cell):
                     properties[0].quantity)
             self._input_auxs.append(netcon)
         elif receive_port.communicates == 'analog':
-            ext_is = self.build_component_class.annotations.get(
-                (BUILD_TRANS, PYPE9_NS), EXTERNAL_CURRENTS).split(',')
-            if receive_port_name not in ext_is:
-                raise Pype9Unsupported9MLException(
-                    "Can only play into external current ports ('{}'), not "
-                    "'{}' port.".format("', '".join(ext_is),
-                                        receive_port_name))
-            raise NotImplementedError
+            raise Pype9UsageError(
+                "Cannot individually 'connect' analog ports. Simulate the "
+                "sending cell in a separate simulation then play the analog "
+                "signal in the port")
         else:
             assert False
 

--- a/test/test_simulations/test_connect.py
+++ b/test/test_simulations/test_connect.py
@@ -3,9 +3,10 @@ import sys
 import logging
 import nineml.units as un
 from nineml.abstraction import (
-    Dynamics, StateVariable, AnalogSendPort, AnalogReceivePort, EventSendPort,
-    EventReceivePort, OutputEvent, Regime, OnEvent, Alias, Parameter,
+    Dynamics, StateVariable, EventSendPort,
+    EventReceivePort, OutputEvent, Regime, OnEvent, Parameter,
     OnCondition, StateAssignment)
+# from nineml.abstraction import Alias, AnalogSendPort, AnalogReceivePort
 from pype9.simulator.neuron import (
     CellMetaClass as NeuronCellMetaClass,
     Simulation as NeuronSimulation)
@@ -83,7 +84,8 @@ class TestConnect(TestCase):
 #             name="StepCurrent",
 #             parameters=[Parameter(dimension=un.current, name="amplitude"),
 #                         Parameter(dimension=un.time, name="onset")],
-#             analog_ports=[AnalogSendPort(name='i_out', dimension=un.current)],
+#             analog_ports=[AnalogSendPort(name='i_out',
+#                                          dimension=un.current)],
 #             state_variables=[StateVariable('i_out', dimension=un.current)],
 #             regimes=[Regime(
 #                 name='default',
@@ -101,9 +103,9 @@ class TestConnect(TestCase):
 #                           AnalogSendPort(name='i_out')],
 #             regimes=[Regime(name='default')])
 #
-#         for CellMetaClass, Simulation in ((NESTCellMetaClass, NESTSimulation),
-#                                           (NeuronCellMetaClass,
-#                                            NeuronSimulation)):
+#         for CellMetaClass, Simulation in (
+#             (NESTCellMetaClass, NESTSimulation),
+#                 (NeuronCellMetaClass, NeuronSimulation)):
 #             Step = CellMetaClass(step9ML)
 #             Relay = CellMetaClass(relay9ML)
 #             with Simulation(dt=0.1 * un.ms) as sim:

--- a/test/test_simulations/test_connect.py
+++ b/test/test_simulations/test_connect.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+import sys
+import logging
+import nineml.units as un
+from nineml.abstraction import (
+    Dynamics, StateVariable, AnalogSendPort, AnalogReceivePort, EventSendPort,
+    EventReceivePort, OutputEvent, Regime, OnEvent, Alias, Parameter,
+    OnCondition, StateAssignment)
+from pype9.simulator.neuron import (
+    CellMetaClass as NeuronCellMetaClass,
+    Simulation as NeuronSimulation)
+argv = sys.argv[1:]  # Save argv before it is clobbered by the NEST init.
+from pype9.simulator.nest import ( # @IgnorePep8
+    CellMetaClass as NESTCellMetaClass,
+    Simulation as NESTSimulation)
+if __name__ == '__main__':
+    from pype9.utils.testing import DummyTestCase as TestCase  # @UnusedImport
+else:
+    from unittest import TestCase  # @Reimport
+
+
+logger = logging.getLogger('PyPe9')
+logger.setLevel(logging.DEBUG)
+handler = logging.StreamHandler(sys.stdout)
+formatter = logging.Formatter(
+    '%(levelname)s - %(message)s')
+handler.setFormatter(formatter)
+logger.addHandler(handler)
+
+
+class TestConnect(TestCase):
+
+    delay = 1 * un.ms
+
+    def test_event_connect(self):  # @UnusedVariable
+
+        rate9ML = Dynamics(
+            name="ConstantRate",
+            parameters=[Parameter('rate', dimension=un.per_time)],
+            state_variables=[StateVariable('t_next', dimension=un.time)],
+            event_ports=[EventSendPort('spike_out')],
+            regimes=[Regime(
+                name='default',
+                transitions=[OnCondition(
+                    't > t_next',
+                    state_assignments=[
+                        StateAssignment('t_next', 't + 1.0/rate')],
+                    output_events=[OutputEvent('spike_out')])])])
+
+        parrot9ML = Dynamics(
+            name="Parrot",
+            regimes=[
+                Regime(name="default",
+                       transitions=[
+                           OnEvent("spike_in",
+                                   output_events=[
+                                       OutputEvent('spike_out')])])],
+            event_ports=[EventReceivePort(name='spike_in'),
+                         EventSendPort(name='spike_out')])
+
+        for CellMetaClass, Simulation in ((NESTCellMetaClass, NESTSimulation),
+                                          (NeuronCellMetaClass,
+                                           NeuronSimulation)):
+            Rate = CellMetaClass(rate9ML)
+            Parrot = CellMetaClass(parrot9ML)
+            with Simulation(dt=0.1 * un.ms) as sim:
+                rate = Rate(rate=100 * un.Hz, t_next=10 * un.ms)
+                parrot = Parrot()
+                parrot.connect(rate, 'spike_out', 'spike_in', delay=self.delay)
+                rate.record('spike_out')
+                parrot.record('spike_out')
+                sim.run(100 * un.ms)
+            rate_spikes = rate.recording('spike_out')
+            parrot_spikes = parrot.recording('spike_out')
+            delay = parrot.UnitHandler.to_pq_quantity(self.delay)
+            self.assertTrue(all(rate_spikes == (parrot_spikes - delay)),
+                            "{} doesn't equal {}".format(rate_spikes,
+                                                         parrot_spikes))
+
+    def test_analog_connect(self):
+
+        step9ML = Dynamics(
+            name="StepCurrent",
+            parameters=[Parameter(dimension=un.current, name="amplitude"),
+                        Parameter(dimension=un.time, name="onset")],
+            analog_ports=[AnalogSendPort(name='i_out', dimension=un.current)],
+            state_variables=[StateVariable('i_out', dimension=un.current)],
+            regimes=[Regime(
+                name='default',
+                transitions=[
+                    OnCondition(
+                        't > onset',
+                        state_assignments=[
+                            StateAssignment('i_out', 'amplitude')],
+                        target_regime='default')])])
+
+        relay9ML = Dynamics(
+            name="Relay",
+            aliases=[Alias('i_out', 'i_in')],
+            analog_ports=[AnalogReceivePort(name='i_in'),
+                          AnalogSendPort(name='i_out')],
+            regimes=[Regime(name='default')])
+
+        for CellMetaClass, Simulation in ((NESTCellMetaClass, NESTSimulation),
+                                          (NeuronCellMetaClass,
+                                           NeuronSimulation)):
+            Step = CellMetaClass(step9ML)
+            Relay = CellMetaClass(relay9ML)
+            with Simulation(dt=0.1 * un.ms) as sim:
+                step = Step(amplitude=50 * un.nA, onset=50 * un.ms,
+                            i_out=0 * un.A)
+                relay = Relay()
+                relay.connect(step, 'i_out', 'i_in', delay=self.delay)
+                step.record('i_out')
+                relay.record('i_out')
+                sim.run(100 * un.ms)
+            step_i = step.recording('spike_out')
+            relay_i = relay.recording('spike_out')
+            delay = relay.UnitHandler.to_pq_quantity(self.delay)
+            self.assertTrue(all(step_i == (relay_i - delay)),
+                            "{} doesn't equal {}".format(step_i, relay_i))

--- a/test/test_simulations/test_connect.py
+++ b/test/test_simulations/test_connect.py
@@ -77,45 +77,45 @@ class TestConnect(TestCase):
                             "{} doesn't equal {}".format(rate_spikes,
                                                          parrot_spikes))
 
-    def test_analog_connect(self):
-
-        step9ML = Dynamics(
-            name="StepCurrent",
-            parameters=[Parameter(dimension=un.current, name="amplitude"),
-                        Parameter(dimension=un.time, name="onset")],
-            analog_ports=[AnalogSendPort(name='i_out', dimension=un.current)],
-            state_variables=[StateVariable('i_out', dimension=un.current)],
-            regimes=[Regime(
-                name='default',
-                transitions=[
-                    OnCondition(
-                        't > onset',
-                        state_assignments=[
-                            StateAssignment('i_out', 'amplitude')],
-                        target_regime='default')])])
-
-        relay9ML = Dynamics(
-            name="Relay",
-            aliases=[Alias('i_out', 'i_in')],
-            analog_ports=[AnalogReceivePort(name='i_in'),
-                          AnalogSendPort(name='i_out')],
-            regimes=[Regime(name='default')])
-
-        for CellMetaClass, Simulation in ((NESTCellMetaClass, NESTSimulation),
-                                          (NeuronCellMetaClass,
-                                           NeuronSimulation)):
-            Step = CellMetaClass(step9ML)
-            Relay = CellMetaClass(relay9ML)
-            with Simulation(dt=0.1 * un.ms) as sim:
-                step = Step(amplitude=50 * un.nA, onset=50 * un.ms,
-                            i_out=0 * un.A)
-                relay = Relay()
-                relay.connect(step, 'i_out', 'i_in', delay=self.delay)
-                step.record('i_out')
-                relay.record('i_out')
-                sim.run(100 * un.ms)
-            step_i = step.recording('spike_out')
-            relay_i = relay.recording('spike_out')
-            delay = relay.UnitHandler.to_pq_quantity(self.delay)
-            self.assertTrue(all(step_i == (relay_i - delay)),
-                            "{} doesn't equal {}".format(step_i, relay_i))
+#     def test_analog_connect(self):
+#
+#         step9ML = Dynamics(
+#             name="StepCurrent",
+#             parameters=[Parameter(dimension=un.current, name="amplitude"),
+#                         Parameter(dimension=un.time, name="onset")],
+#             analog_ports=[AnalogSendPort(name='i_out', dimension=un.current)],
+#             state_variables=[StateVariable('i_out', dimension=un.current)],
+#             regimes=[Regime(
+#                 name='default',
+#                 transitions=[
+#                     OnCondition(
+#                         't > onset',
+#                         state_assignments=[
+#                             StateAssignment('i_out', 'amplitude')],
+#                         target_regime='default')])])
+#
+#         relay9ML = Dynamics(
+#             name="Relay",
+#             aliases=[Alias('i_out', 'i_in')],
+#             analog_ports=[AnalogReceivePort(name='i_in'),
+#                           AnalogSendPort(name='i_out')],
+#             regimes=[Regime(name='default')])
+#
+#         for CellMetaClass, Simulation in ((NESTCellMetaClass, NESTSimulation),
+#                                           (NeuronCellMetaClass,
+#                                            NeuronSimulation)):
+#             Step = CellMetaClass(step9ML)
+#             Relay = CellMetaClass(relay9ML)
+#             with Simulation(dt=0.1 * un.ms) as sim:
+#                 step = Step(amplitude=50 * un.nA, onset=50 * un.ms,
+#                             i_out=0 * un.A)
+#                 relay = Relay()
+#                 relay.connect(step, 'i_out', 'i_in', delay=self.delay)
+#                 step.record('i_out')
+#                 relay.record('i_out')
+#                 sim.run(100 * un.ms)
+#             step_i = step.recording('spike_out')
+#             relay_i = relay.recording('spike_out')
+#             delay = relay.UnitHandler.to_pq_quantity(self.delay)
+#             self.assertTrue(all(step_i == (relay_i - delay)),
+#                             "{} doesn't equal {}".format(step_i, relay_i))


### PR DESCRIPTION
Adds the ability to connect event ports of single cells together. Decided agains allowing analog port connections as they could require special handling (e.g. gap junctions) and it is not straightforward to add in NEST and NEURON